### PR TITLE
sACN priority fixed

### DIFF
--- a/DMXUniverse.cpp
+++ b/DMXUniverse.cpp
@@ -10,15 +10,15 @@
 
 #include "JuceHeader.h"
 
-DMXUniverse::DMXUniverse(int net, int subnet, int universe) :
-	net(net), subnet(subnet), universe(universe),
+DMXUniverse::DMXUniverse(int net, int subnet, int universe, int priority) :
+	net(net), subnet(subnet), universe(universe), priority(priority),
 	isDirty(true)
 {
 	values.resize(DMX_NUM_CHANNELS);
 }
 
 DMXUniverse::DMXUniverse(int universeIndex) :
-	DMXUniverse((universeIndex >> 8) & 0xf, (universeIndex >> 4) & 0xf, universeIndex & 0x7f)
+	DMXUniverse((universeIndex >> 8) & 0xf, (universeIndex >> 4) & 0xf, universeIndex & 0x7f, 100)
 {
 }
 
@@ -71,7 +71,7 @@ void DMXUniverse::updateValues(Array<uint8> newValues, bool dirtyIfDifferent)
 
 DMXUniverseItem::DMXUniverseItem(bool useParams, int firstUniverse) :
 	BaseItem("Universe", false, false),
-	DMXUniverse(0, 0, firstUniverse),
+	DMXUniverse(0, 0, firstUniverse, 100),
 	useParams(useParams)
 {
 	editorIsCollapsed = useParams;
@@ -79,6 +79,7 @@ DMXUniverseItem::DMXUniverseItem(bool useParams, int firstUniverse) :
 	netParam = addIntParameter("Net", "If appliccable the net for this universe", 0, 0, 15);
 	subnetParam = addIntParameter("Subnet", "If applicable the subnet for this universe", 0, 0, 15);
 	universeParam = addIntParameter("Universe", "The universe", firstUniverse, firstUniverse);
+	priorityParam = addIntParameter("Priority", "The SACN priority of the universe", 100, 0, 200);
 	
 	if (useParams)
 	{
@@ -157,6 +158,7 @@ void DMXUniverseItem::onContainerParameterChangedInternal(Parameter* p)
 	if (p == netParam) net = netParam->intValue();
 	else if (p == subnetParam) subnet = subnetParam->intValue();
 	else if (p == universeParam) universe = universeParam->intValue();
+	else if (p == priorityParam) priority = priorityParam->intValue();
 	else
 	{
 		if (!useParams) return;

--- a/DMXUniverse.h
+++ b/DMXUniverse.h
@@ -78,7 +78,7 @@ public:
 class DMXUniverse
 {
 public:
-	DMXUniverse(int net, int subnet, int universe);
+	DMXUniverse(int net, int subnet, int universe, int priority);
 	DMXUniverse(int universeIndex);
 	DMXUniverse(DMXUniverse* universeToCopy);
 
@@ -87,6 +87,7 @@ public:
 	int net;
 	int subnet;
 	int universe;
+	int priority;
 
 	bool isDirty;
 
@@ -114,6 +115,7 @@ public:
 	IntParameter* netParam;
 	IntParameter* subnetParam;
 	IntParameter* universeParam;
+	IntParameter* priorityParam;
 
 	bool useParams;
 	Array<DMXValueParameter*> valueParams;

--- a/device/DMXArtNetDevice.cpp
+++ b/device/DMXArtNetDevice.cpp
@@ -103,7 +103,7 @@ void DMXArtNetDevice::setupReceiver()
 //
 //}
 
-void DMXArtNetDevice::sendDMXValuesInternal(int net, int subnet, int universe, uint8* values, int numChannels)
+void DMXArtNetDevice::sendDMXValuesInternal(int net, int subnet, int universe, int priority, uint8* values, int numChannels)
 {
 	sequenceNumber = (sequenceNumber + 1) % 256;
 
@@ -187,7 +187,7 @@ void DMXArtNetDevice::run()
 
 				String sName = rAddress + ":" + String(rPort);
 				Array<uint8> values = Array<uint8>(receiveBuffer + DMX_HEADER_LENGTH, DMX_NUM_CHANNELS);
-				setDMXValuesIn(net, subnet, universe, values, sName);
+				setDMXValuesIn(net, subnet, universe, 100, values, sName);
 
 			}
 			break;

--- a/device/DMXArtNetDevice.h
+++ b/device/DMXArtNetDevice.h
@@ -47,7 +47,7 @@ public:
 	//void sendDMXValue(int channel, int value) override;
 	//void sendDMXRange(int startChannel, Array<int> values) override;
 
-	void sendDMXValuesInternal(int net, int subnet, int universe, uint8* values, int numChannels) override;
+	void sendDMXValuesInternal(int net, int subnet, int universe, int priority, uint8* values, int numChannels) override;
 
 	//	void endLoadFile() override;
 

--- a/device/DMXDevice.cpp
+++ b/device/DMXDevice.cpp
@@ -107,10 +107,10 @@ bool DMXDevice::shouldHaveConnectionParam()
 //	
 //}
 
-void DMXDevice::setDMXValuesIn(int net, int subnet, int universe, Array<uint8> values, const String& sourceName)
+void DMXDevice::setDMXValuesIn(int net, int subnet, int universe, int priority, Array<uint8> values, const String& sourceName)
 {
 	jassert(values.size() == DMX_NUM_CHANNELS);
-	dmxDeviceListeners.call(&DMXDeviceListener::dmxDataInChanged, this, net, subnet, universe, values, sourceName);
+	dmxDeviceListeners.call(&DMXDeviceListener::dmxDataInChanged, this, net, subnet, universe, priority, values, sourceName);
 }
 
 
@@ -127,14 +127,14 @@ int DMXDevice::getFirstUniverse()
 void DMXDevice::sendDMXValues(DMXUniverse* u, int numChannels)
 {
 	if (!outputCC->enabled->boolValue()) return;
-	sendDMXValues(u->net, u->subnet, u->universe, u->values.getRawDataPointer(), numChannels);
+	sendDMXValues(u->net, u->subnet, u->universe, u->priority, u->values.getRawDataPointer(), numChannels);
 }
 
-void DMXDevice::sendDMXValues(int net, int subnet, int universe, uint8* values, int numChannels)
+void DMXDevice::sendDMXValues(int net, int subnet, int universe, int priority, uint8* values, int numChannels)
 {
 	if (!outputCC->enabled->boolValue()) return;
 	ScopedLock lock(dmxLock);
-	sendDMXValuesInternal(net, subnet, universe, values, jmin(numChannels, DMX_NUM_CHANNELS));
+	sendDMXValuesInternal(net, subnet, universe, priority, values, jmin(numChannels, DMX_NUM_CHANNELS));
 }
 
 

--- a/device/DMXDevice.h
+++ b/device/DMXDevice.h
@@ -42,10 +42,10 @@ public:
 	//virtual void sendDMXValue(int net, int subnet, int universe, int channel, int value);
 	//virtual void sendDMXRange(int net, int subnet, int universe, int startChannel, Array<int> values);
 	virtual void sendDMXValues(DMXUniverse* u, int numChannels = DMX_NUM_CHANNELS);
-	virtual void sendDMXValues(int net, int subnet, int universe, uint8* values, int numChannels = DMX_NUM_CHANNELS);
-	virtual void sendDMXValuesInternal(int net, int subnet, int universe, uint8* values, int numChannels = DMX_NUM_CHANNELS) = 0;
+	virtual void sendDMXValues(int net, int subnet, int universe, int priority, uint8* values, int numChannels = DMX_NUM_CHANNELS);
+	virtual void sendDMXValuesInternal(int net, int subnet, int universe, int priority, uint8* values, int numChannels = DMX_NUM_CHANNELS) = 0;
 
-	void setDMXValuesIn(int net, int subnet, int universe, Array<uint8> values, const String& sourceName = "");
+	void setDMXValuesIn(int net, int subnet, int universe, int priority, Array<uint8> values, const String& sourceName = "");
 
 	void onControllableFeedbackUpdate(ControllableContainer* cc, Controllable* c) override;
 
@@ -61,7 +61,7 @@ public:
 		virtual ~DMXDeviceListener() {}
 
 		virtual void dmxDeviceSetupChanged(DMXDevice* device) {}
-		virtual void dmxDataInChanged(DMXDevice*, int net, int subnet, int universe, Array<uint8> values, const String& sourceName = "") {}
+		virtual void dmxDataInChanged(DMXDevice*, int net, int subnet, int universe, int priority, Array<uint8> values, const String& sourceName = "") {}
 	};
 
 	ListenerList<DMXDeviceListener> dmxDeviceListeners;

--- a/device/DMXEnttecProDevice.cpp
+++ b/device/DMXEnttecProDevice.cpp
@@ -176,6 +176,6 @@ void DMXEnttecProDevice::readDMXPacket(Array<uint8> bytes, int expectedLength)
 		return;
 	}
 
-	setDMXValuesIn(0, 0, 0, Array<uint8>(bytes.getRawDataPointer() + DMXPRO_HEADER_LENGTH + 1, DMX_NUM_CHANNELS));
+	setDMXValuesIn(0, 0, 0, 100, Array<uint8>(bytes.getRawDataPointer() + DMXPRO_HEADER_LENGTH + 1, DMX_NUM_CHANNELS));
 }
 

--- a/device/DMXSACNDevice.h
+++ b/device/DMXSACNDevice.h
@@ -37,7 +37,7 @@ public:
 	StringParameter* nodeName;
 	//BoolParameter* sendMulticast;
 	//IntParameter* outputUniverse;
-	IntParameter* priority;
+	//IntParameter* priority;
 
 	//Receiver
 	//int receiverHandle;
@@ -68,7 +68,7 @@ public:
 	//void sendDMXValue(int channel, int value) override;
 	//void sendDMXRange(int startChannel, Array<int> values) override;
 
-	void sendDMXValuesInternal(int net, int subnet, int universe, uint8* values, int numChannels) override;
+	void sendDMXValuesInternal(int net, int subnet, int universe, int priority, uint8* values, int numChannels) override;
 
 	//	void endLoadFile() override;
 

--- a/device/DMXSerialDevice.cpp
+++ b/device/DMXSerialDevice.cpp
@@ -107,7 +107,7 @@ bool DMXSerialDevice::shouldHaveConnectionParam()
 	return true;
 }
 
-void DMXSerialDevice::sendDMXValuesInternal(int net, int subnet, int universe, uint8* values, int numChannels)
+void DMXSerialDevice::sendDMXValuesInternal(int net, int subnet, int universe, int priority, uint8* values, int numChannels)
 {
 	if (dmxPort == nullptr) return;
 

--- a/device/DMXSerialDevice.h
+++ b/device/DMXSerialDevice.h
@@ -40,7 +40,7 @@ public:
 	virtual bool shouldHaveConnectionParam() override;
 
 	virtual void initRunLoop() {}
-	virtual void sendDMXValuesInternal(int net, int subnet, int universe, uint8* values, int numChannels) override;
+	virtual void sendDMXValuesInternal(int net, int subnet, int universe, int priority, uint8* values, int numChannels) override;
 	virtual void sendDMXValuesSerialInternal(int net, int subnet, int universe, uint8* values, int numChannels) = 0;
 
 	virtual void onContainerParameterChanged(Parameter * p) override;


### PR DESCRIPTION
The sACN priority functionality was not working in the DMX module. It would only ever send priority 100. This was found to be due to the fact that the library used set 10 as default (correctly), but there was never any code added to implement to control in Chataigne to actually update this.
Since the priority is sent with every universe packet, it made sense to do this on a per-Universe basis, so the priority was moved to the universe settings, below the network and the actual universe number. The relevant functions were updated to use priority where necessary, but no other DMX types should be affected.
This change necessitated changes to both the main code body, as well as juce-dmx.