### PR TITLE
Fix for segfault on DMX Enttec PRO input

### DIFF
--- a/device/DMXEnttecProDevice.cpp
+++ b/device/DMXEnttecProDevice.cpp
@@ -176,6 +176,9 @@ void DMXEnttecProDevice::readDMXPacket(Array<uint8> bytes, int expectedLength)
 		return;
 	}
 
-	setDMXValuesIn(0, 0, 0, Array<uint8>(bytes.getRawDataPointer() + DMXPRO_HEADER_LENGTH + 1, DMX_NUM_CHANNELS));
+	Array<uint8> values = Array<uint8>(bytes.getRawDataPointer() + DMXPRO_HEADER_LENGTH + 1, bytes.size() - DMXPRO_HEADER_LENGTH - 1);
+	values.resize(DMX_NUM_CHANNELS);
+
+	setDMXValuesIn(0, 0, 0, values);
 }
 


### PR DESCRIPTION
Fix for the DMX Enttec Pro input buffer insecure memory access casing random segfaults if the device is returning less than 512 values.

In this fix, the buffer is only filled with the correct amount of values and then filled with extra zeros if needed.